### PR TITLE
fixed pk method. Now output list can have spaces

### DIFF
--- a/python/classy.pyx
+++ b/python/classy.pyx
@@ -698,7 +698,7 @@ cdef class Class:
         cdef double *pk_ic = <double*> calloc(self.sp.ic_ic_size[self.sp.index_md_scalars], sizeof(double))
         abort = True
         if 'output' in self._pars:
-            options = self._pars['output'].split(',')
+            options = self._pars['output'].replace(' ', '').split(',')
             for option in options:
                 if option in ['mPk', 'mTk', 'vTk']:
                     abort = False


### PR DESCRIPTION
Added `.replace(' ', '')` to remove possible spaces in the output variable (e.g.` "tCl, mPk"`). Otherwise, it would split it to `["tCl", " mPk"]` and would not see that matter power spectrum was computed.