### PR TITLE
Corrected bug when integrating M2 (thanks to Bill Wright)

### DIFF
--- a/source/background.c
+++ b/source/background.c
@@ -3262,7 +3262,7 @@ int background_derivs(
     }
     /** - Planck mass equation (if parameterization in terms of alpha_m **/
     if (pba->M_pl_evolution_smg == _TRUE_)
-      dy[pba->index_bi_delta_M_pl_smg] = y[pba->index_bi_a]*pvecback[pba->index_bg_H]*pvecback[pba->index_bg_mpl_running_smg]*y[pba->index_bi_delta_M_pl_smg];   //in this case the running has to be integrated (eq 3.3 of 1404.3713 yields M2' = aH\alpha_M)
+      dy[pba->index_bi_delta_M_pl_smg] = y[pba->index_bi_a]*pvecback[pba->index_bg_H]*pvecback[pba->index_bg_mpl_running_smg]*(y[pba->index_bi_delta_M_pl_smg]+1.);   //in this case the running has to be integrated (eq 3.3 of 1404.3713 yields M2' = aH\alpha_M)
   }
 
   if (pba->has_fld == _TRUE_) {


### PR DESCRIPTION
This is affecting hi_class since I replaced M2 with delta_M2.
The equation was M2' = a*H*alpha_M*M2
and I simply replaced with delta_M2' = a*H*alpha_M*delta_M2
(sorry!)
Now it's corrected and became delta_M2' = a*H*alpha_M*(1+delta_M2)
